### PR TITLE
fix: restore cross-platform release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev soak stress test test-race install-golangci-lint lint check
+.PHONY: build dev soak stress test test-race test-release-build install-golangci-lint lint check
 
 BIN ?= tgfile
 GO ?= go
@@ -53,6 +53,11 @@ test:
 test-race:
 	GOCACHE=$(GOCACHE) $(GO) test -count=1 -race ./...
 
+test-release-build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOCACHE=$(GOCACHE) $(GO) build -o /dev/null ./cmd
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GOCACHE=$(GOCACHE) $(GO) build -o /dev/null ./cmd
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 GOCACHE=$(GOCACHE) $(GO) build -o /dev/null ./cmd
+
 install-golangci-lint:
 	GOBIN=$(GOBIN) GOCACHE=$(GOCACHE) $(GO) install \
 		github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
@@ -66,4 +71,5 @@ check:
 	$(GO) vet ./...
 	$(MAKE) test
 	$(MAKE) test-race
+	$(MAKE) test-release-build
 	$(MAKE) lint

--- a/backupmgr/disk_space.go
+++ b/backupmgr/disk_space.go
@@ -1,0 +1,18 @@
+package backupmgr
+
+import (
+	"math"
+	"math/big"
+)
+
+func saturatingFilesystemBytes(blocks, blockSize uint64) int64 {
+	if blocks == 0 || blockSize == 0 {
+		return 0
+	}
+	product := new(big.Int).SetUint64(blocks)
+	product.Mul(product, new(big.Int).SetUint64(blockSize))
+	if !product.IsInt64() {
+		return math.MaxInt64
+	}
+	return product.Int64()
+}

--- a/backupmgr/disk_space_posix.go
+++ b/backupmgr/disk_space_posix.go
@@ -1,0 +1,19 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package backupmgr
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func filesystemFreeBytes(workDir string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(workDir, &stat); err != nil {
+		return 0, fmt.Errorf("stat filesystem: %w", err)
+	}
+	if stat.Bsize <= 0 {
+		return 0, syscall.EINVAL
+	}
+	return saturatingFilesystemBytes(stat.Bavail, uint64(stat.Bsize)), nil
+}

--- a/backupmgr/disk_space_test.go
+++ b/backupmgr/disk_space_test.go
@@ -1,0 +1,41 @@
+package backupmgr
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaturatingFilesystemBytes(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		blocks    uint64
+		blockSize uint64
+		expected  int64
+	}{
+		{name: "no blocks", blocks: 0, blockSize: 4096, expected: 0},
+		{name: "zero block size", blocks: 10, blockSize: 0, expected: 0},
+		{name: "normal filesystem", blocks: 1024, blockSize: 4096, expected: 4 * 1024 * 1024},
+		{
+			name:      "largest representable value",
+			blocks:    uint64(math.MaxInt64),
+			blockSize: 1,
+			expected:  math.MaxInt64,
+		},
+		{
+			name:      "overflow saturates",
+			blocks:    uint64(math.MaxInt64),
+			blockSize: 2,
+			expected:  math.MaxInt64,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				test.expected,
+				saturatingFilesystemBytes(test.blocks, test.blockSize),
+			)
+		})
+	}
+}

--- a/backupmgr/disk_space_windows.go
+++ b/backupmgr/disk_space_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package backupmgr
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func filesystemFreeBytes(workDir string) (int64, error) {
+	directoryName, err := windows.UTF16PtrFromString(workDir)
+	if err != nil {
+		return 0, fmt.Errorf("encode filesystem path: %w", err)
+	}
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(directoryName, &available, nil, nil); err != nil {
+		return 0, fmt.Errorf("query filesystem space: %w", err)
+	}
+	return saturatingFilesystemBytes(available, 1), nil
+}

--- a/backupmgr/manager.go
+++ b/backupmgr/manager.go
@@ -1758,8 +1758,8 @@ func ensureFreeSpace(workDir string, payloadBytes int64) error {
 	if payloadBytes < 0 {
 		return ErrInvalidRequest
 	}
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(workDir, &stat); err != nil {
+	available, err := filesystemFreeBytes(workDir)
+	if err != nil {
 		return fmt.Errorf("inspect backup work space: %w", err)
 	}
 	const gib = int64(1024 * 1024 * 1024)
@@ -1772,7 +1772,6 @@ func ensureFreeSpace(workDir string, payloadBytes int64) error {
 		return backupfmt.ErrLimitExceeded
 	}
 	required += margin
-	available := int64(stat.Bavail) * stat.Bsize //nolint:gosec // Statfs values are non-negative.
 	if available < required {
 		return fmt.Errorf("backup work directory requires %d free bytes: %w", required, syscall.ENOSPC)
 	}


### PR DESCRIPTION
## Root cause

The v0.0.41 release build used `syscall.Statfs` directly in shared code. Windows does not expose that API, and Darwin uses a different `Statfs_t.Bsize` type, so both release targets failed to compile.

Failed run: https://github.com/xxxsen/tgfile/actions/runs/30197538871

## Changes

- split filesystem free-space lookup into POSIX and Windows implementations
- use overflow-safe saturated byte calculation
- add unit coverage for boundary and overflow cases
- add Linux, Darwin, and Windows cross-builds to `make check`

## Verification

- `make check GO=/home/sen/work/go/bin/go`
- Linux amd64 cross-build
- Darwin amd64 cross-build
- Windows amd64 cross-build
- lint: 0 issues
